### PR TITLE
Fix caching and other improvements

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,8 +1,8 @@
 # Latest Github Release
-Automatically add a download link to the latest Github repo release zips with a shortcode [latest_github_release user="Github" repo="years-since"]
+Automatically add a download link to the latest Github repo release zips with a shortcode [latest_github_release user="github" repo="hub"]
 
 # Usage
-Add the shortcode ```[latest_github_release user="Github" repo="years-since"]``` to desired post/page/widget and save to have the code working.
+Add the shortcode ```[latest_github_release user="github" repo="hub"]``` to desired post/page/widget and save to have the code working.
 
 ## Options
 One can add some customization to the shortcode such as 

--- a/Readme.txt
+++ b/Readme.txt
@@ -1,12 +1,14 @@
 = Latest Github Release =
-Automatically add a download link to the latest Github repo release zips with a shortcode [latest_github_release user="Github" repo="years-since"]
+Automatically add a download link to the latest Github repo release zips with
+a shortcode [latest_github_release user="github" repo="hub"]
 
 == Description ==
 
-Automatically add a download link to the latest Github repo release zips with a shortcode [latest_github_release user="Github" repo="years-since"]
+Automatically add a download link to the latest Github repo release zips with
+a shortcode [latest_github_release user="github" repo="hub"]
 
 == Usage ==
-Add the shortcode ```[latest_github_release user="Github" repo="years-since"]``` to desired post/page/widget and save to have the code working.
+Add the shortcode ```[latest_github_release user="github" repo="hub"]``` to desired post/page/widget and save to have the code working.
 
 === options ===
 One can add some customization to the shortcode such as 

--- a/latest-github-release.php
+++ b/latest-github-release.php
@@ -41,7 +41,7 @@ class LatestGithubRelease {
 	 * @since 0.1.0
 	 *
 	 * @param array $atts Shortcode arguments.
-	 * @return string <a href="url" class="cp-release-link">$atts[name] . ' ' . $atts[type]</a>
+	 * @return string <a href="(zip url)" class="cp-release-link">$atts[name]</a>
 	 */
 	public function process_shortcode( $atts ) {
 		// Default values for when not passed in shortcode.

--- a/latest-github-release.php
+++ b/latest-github-release.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Latest Github Release
- * Description: Automatically add a download link to the latest Github repo release zips with a shortcode like [latest_github_release user="Github" repo="years-since"]
+ * Description: Automatically add a download link to the latest Github repo release zips with a shortcode like [latest_github_release user="github" repo="hub"]
  * Version: 1.1.0
  * Author: Laurence Bahiirwa
  * Author URI: https://omukiguy.com

--- a/latest-github-release.php
+++ b/latest-github-release.php
@@ -146,20 +146,6 @@ class LatestGithubRelease {
 	}
 
 	/**
-	 * On deactivation. Clear the links transient created in DB.
-	 *
-	 * @since 0.1.0
-	 */
-	public function deactivation($atts) {
-
-		$transient = $this->lg_release_zip . '_' . $atts['repo'];
-		if ( true == get_transient( $transient ) ) {
-			delete_transient( $transient );
-		}
-		
-	}
-
-	/**
 	 * Return the name of the transient that should be used to cache the
 	 * release information for a repository.
 	 *
@@ -176,5 +162,3 @@ class LatestGithubRelease {
 // On Activation. Start the Plugin class.
 $CP_release_link = new LatestGithubRelease;
 $CP_release_link->register();
-
-register_deactivation_hook(__FILE__, array( 'LatestGithubRelease', 'deactivation' ) );

--- a/latest-github-release.php
+++ b/latest-github-release.php
@@ -7,33 +7,30 @@
  * Author URI: https://omukiguy.com
  * Plugin URI: https://github.com/bahiirwa/latest-github-release
  * Text Domain: latest_github_release
- * 
+ *
  * This is free software released under the terms of the General Public License,
  * version 2, or later. It is distributed WITHOUT ANY WARRANTY; without even the
  * implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. Full
  * text of the license is available at https://www.gnu.org/licenses/gpl-2.0.txt.
- * 
+ *
  */
 
 namespace bahiirwa\LatestGithubRelease;
 
-
 // Prevent direct access.
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
 	die();
 }
 
 class LatestGithubRelease {
 	/**
-	 * Add action to Process shortcodes.
+	 * Add action to process shortcodes.
 	 *
 	 * @since 0.1.0
 	 *
 	 */
 	public function register() {
-	
-		add_shortcode('latest_github_release', array($this, 'process_shortcode'));
-
+		add_shortcode( 'latest_github_release', [ $this, 'process_shortcode' ] );
 	}
 
 	/**
@@ -46,12 +43,11 @@ class LatestGithubRelease {
 	 * @param array $atts Shortcode arguments.
 	 * @return string <a href="url" class="cp-release-link">$atts[name] . ' ' . $atts[type]</a>
 	 */
-	public function process_shortcode($atts) {
-		
+	public function process_shortcode( $atts ) {
 		// Default values for when not passed in shortcode.
 		$defaults = [
-			'repo' => '',
 			'user' => '',
+			'repo' => '',
 			// set default button name to Download
 			'name' => 'Download Zip',
 		];
@@ -60,7 +56,8 @@ class LatestGithubRelease {
 		$atts = shortcode_atts(
 			$defaults,
 			$atts,
-			'latest_github_release');
+			'latest_github_release'
+		);
 
 		// Validate the user and the repo.
 		if ( empty( $atts['user'] ) || empty( $atts['repo'] ) ) {

--- a/latest-github-release.php
+++ b/latest-github-release.php
@@ -2,8 +2,8 @@
 /**
  * Plugin Name: Latest Github Release
  * Description: Automatically add a download link to the latest Github repo release zips with a shortcode like [latest_github_release user="github" repo="hub"]
- * Version: 1.1.0
- * Author: Laurence Bahiirwa
+ * Version: 1.2.0
+ * Author: Laurence Bahiirwa, James Nylen
  * Author URI: https://omukiguy.com
  * Plugin URI: https://github.com/bahiirwa/latest-github-release
  * Text Domain: latest_github_release


### PR DESCRIPTION
This PR fixes several issues with this plugin, mostly related to the caching using transients:

- The transient names used when reading a cached value were not the same as the transient name used when saving the cached value. This would cause the plugin to act like there was no caching in place.
- The transient name only included the repository name, not the user or organization name. This would cause the plugin to break when if a site uses the shortcode for the same repository name under two different users.
- Long user or repository names could exceed the maximum length of a transient's name. I am not sure whether this would cause an error or just disable the caching but this should be fixed.
- The plugin's deactivation hook did not work.

The first three issues have been fixed by introducing a `get_transient_name` function to calculate the name of a transient based on a set of shortcode parameters, and the last has been fixed by removing the deactivation callback - it's not needed because transients will be cleaned up automatically anyway.

Other changes are minor, including a version bump and adding myself to the authors list. See the commit messages for more details.