### PR TITLE
Rewrite for v2.0.0

### DIFF
--- a/latest-github-release.php
+++ b/latest-github-release.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Latest Github Release
  * Description: Automatically add a download link to the latest Github repo release zips with a shortcode like [latest_github_release user="github" repo="hub"]
- * Version: 1.2.0
+ * Version: 2.0.0
  * Author: Laurence Bahiirwa, James Nylen
  * Author URI: https://omukiguy.com
  * Plugin URI: https://github.com/bahiirwa/latest-github-release
@@ -27,10 +27,11 @@ class LatestGithubRelease {
 	 * Add action to process shortcodes.
 	 *
 	 * @since 0.1.0
+	 * @since 2.0.0 The function is now static.
 	 *
 	 */
-	public function register() {
-		add_shortcode( 'latest_github_release', [ $this, 'process_shortcode' ] );
+	public static function register() {
+		add_shortcode( 'latest_github_release', [ __CLASS__, 'process_shortcode' ] );
 	}
 
 	/**
@@ -39,17 +40,18 @@ class LatestGithubRelease {
 	 * This public function processes the cp_release_link shortcode into HTML markup.
 	 *
 	 * @since 0.1.0
+	 * @since 2.0.0 The function is now static.
 	 *
 	 * @param array $atts Shortcode arguments.
 	 * @return string <a href="(zip url)" class="cp-release-link">$atts[name]</a>
 	 */
-	public function process_shortcode( $atts ) {
+	public static function process_shortcode( $atts ) {
 		// Default values for when not passed in shortcode.
 		$defaults = [
-			'user' => '',
-			'repo' => '',
-			// set default button name to Download
-			'name' => 'Download Zip',
+			'user'  => '',
+			'repo'  => '',
+			'name'  => 'Download Zip', // default button name
+			'class' => 'latest-github-release-link',
 		];
 
 		// Replace any missing shortcode arguments with defaults.
@@ -61,46 +63,107 @@ class LatestGithubRelease {
 
 		// Validate the user and the repo.
 		if ( empty( $atts['user'] ) || empty( $atts['repo'] ) ) {
-			return '<!-- [latest_github_release] missing user or repo! -->';
+			return '<!-- [latest_github_release] Missing user or repo! -->';
 		}
 
+		// Get the release data from GitHub.
+		$release_data = self::get_release_data_cached( $atts );
+		if ( is_wp_error( $release_data ) ) {
+			return (
+				'<!-- [latest_github_release] '
+				. esc_html( $release_data->get_error_message() )
+				. ' -->'
+			);
+		}
+
+		// Get the URL to a release zipfile.
+		$zip_url = self::get_zip_url_for_release( $release_data );
+		if ( is_wp_error( $zip_url ) ) {
+			return (
+				'<!-- [latest_github_release] '
+				. esc_html( $zip_url->get_error_message() )
+				. ' -->'
+			);
+		}
+
+		$html = (
+			'<a href="' . esc_attr( $zip_url ) . '"'
+			. ' class="' . esc_attr( $atts['class'] ) . '">'
+			. esc_html( $atts['name'] )
+			. '</a>'
+		);
+
+		/**
+		 * Filters the HTML for the release link.
+		 *
+		 * @since 2.0.0
+		 *
+		 * @param string $html The link HTML.
+		 * @param array  $atts The full array of shortcode attributes.
+		 */
+		return apply_filters( 'latest_github_release_link', $html, $atts );
+	}
+
+	/**
+	 * Fetch release data from GitHub or return it from a cached value.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param array $atts Array containing 'user' and 'repo' arguments.
+	 * @return array|\WP_Error Release data from GitHub, or an error object.
+	 */
+	public static function get_release_data_cached( $atts ) {
 		// Get any existing copy of our transient data
-		$zip_url = get_transient( $this->get_transient_name( $atts ) );
+		$release_data = get_transient( self::get_transient_name( $atts ) );
 
-		if ( empty( $zip_url ) ) {
-			$zip_url = $this->get_release_zip_url( $atts );
+		if ( empty( $release_data ) ) {
+			$release_data = self::get_release_data( $atts );
 
-			if ( empty( $zip_url ) ) {
-				// An error occurred, and the `get_release_zip_url()` function
-				// should have already echoed an appropriate message inside a
-				// comment.
-				return '';
+			if ( is_wp_error( $release_data ) ) {
+				return $release_data;
 			}
 
-			// Save zip link in transient inside DB to reduce network calls.
+			// Save release data in transient inside DB to reduce network calls.
 			set_transient(
-				$this->get_transient_name( $atts ),
-				$zip_url,
+				self::get_transient_name( $atts ),
+				$release_data,
 				15 * MINUTE_IN_SECONDS
 			);
 		}
 
+		return $release_data;
+	}
+
+	/**
+	 * Return the name of the transient that should be used to cache the
+	 * release information for a repository.
+	 *
+	 * @since 1.2.0
+	 * @since 2.0.0 The function is now static, and the transient names have
+	 * changed because the full release data is stored instead of just the URL
+	 * to a zip file.
+	 *
+	 * @param array $atts Array containing 'user' and 'repo' arguments.
+	 * @return string Transient name to use for caching this repository.
+	 */
+	public static function get_transient_name( $atts ) {
 		return (
-			'<a href="' . $zip_url . '" class="cp-release-link">'
-			. $atts['name']
-			. '</a>'
+			'lgr_api_'
+			. substr( md5( $atts['user'] . '/' . $atts['repo'] ), 0, 16 )
 		);
 	}
 
 	/**
-	 * Call out to the GitHub API to get a release zip URL for the given repository.
+	 * Fetch release data from GitHub.
 	 *
-	 * @since 1.2.0
+	 * @since 2.0.0
+	 *
+	 * @internal - use self::get_release_data_cached() instead.
 	 *
 	 * @param array $atts Array containing 'user' and 'repo' arguments.
-	 * @return string URL of latest zip release file on GitHub.
+	 * @return array|\WP_Error Release data from GitHub, or an error object.
 	 */
-	public function get_release_zip_url( $atts ) {
+	private static function get_release_data( $atts ) {
 		// Build the GitHub API URL for the latest release.
 		$api_url = (
 			'https://api.github.com/repos/'
@@ -110,52 +173,63 @@ class LatestGithubRelease {
 
 		// Make API call.
 		$response = wp_remote_get( esc_url_raw( $api_url ) );
-		// Error catch for failed API call.
+
 		if ( is_wp_error( $response ) ) {
-			echo '<!-- [latest_github_release] error: ';
-			echo esc_html( $response->get_error_message() );
-			echo ' -->';
-			return null;
+			return $response;
 		}
 
 		// Parse the JSON response from the API into an array of data.
-		$api_response = json_decode( wp_remote_retrieve_body( $response ), true );
+		$response_body = wp_remote_retrieve_body( $response );
+		$response_json = json_decode( $response_body, true );
+		$status_code = wp_remote_retrieve_response_code( $response );
 
-		// If any files were uploaded for this release, use the first one.
-		// TODO: Allow specifying which file to use somehow (name regex?)
-		if ( ! empty( $api_response['assets'] ) ) {
-			return $api_response['assets'][0]['browser_download_url'];
+		if ( empty( $response_json ) || $status_code !== 200 ) {
+			return new \WP_Error(
+				'invalid_data',
+				'Invalid data returned from GitHub',
+				[
+					'code' => $status_code,
+					'body' => empty( $response_json ) ? $response_body : $response_json,
+				]
+			);
 		}
 
-		// Otherwise, build a URL based on the tag name of the latest release.
-		$version = $api_response['tag_name'];
-
-		if ( empty( $version ) ) {
-			echo '<!-- [latest_github_release] no releases found! -->';
-			return null;
-		}
-
-		return (
-			'https://github.com/'
-			. $atts['user'] . '/' . $atts['repo']
-			. '/archive/' . $version . '.zip'
-		);
+		return $response_json;
 	}
 
 	/**
-	 * Return the name of the transient that should be used to cache the
-	 * release information for a repository.
+	 * Given a set of release data from the GitHub API, return a release zip URL.
 	 *
-	 * @since 1.2.0
+	 * @since 2.0.0
 	 *
-	 * @param array $atts Array containing 'user' and 'repo' arguments.
-	 * @return string Transient name to use for caching this repository.
+	 * @param array $release_data Release data from the GitHub API.
+	 * @return string URL of latest zip release file on GitHub.
 	 */
-	public function get_transient_name( $atts ) {
-		return 'lgr_' . substr( md5( $atts['user'] . '/' . $atts['repo'] ), 0, 16 );
+	public static function get_zip_url_for_release( $release_data ) {
+		// If any files were uploaded for this release, use the first one.
+		// TODO: Allow specifying which file to use somehow (name regex?)
+		if ( ! empty( $release_data['assets'] ) ) {
+			return $release_data['assets'][0]['browser_download_url'];
+		}
+
+		// Otherwise, build a URL based on the tag name of the latest release.
+		$version = $release_data['tag_name'];
+
+		// Extract the user and repo name from the GitHub API URL.
+		preg_match(
+			'#^https://api\.github\.com/repos/([^/]+)/([^/]+)/releases/#',
+			$release_data['url'],
+			$matches
+		);
+		$user = $matches[1];
+		$repo = $matches[2];
+
+		return (
+			'https://github.com/'
+			. $user . '/' . $repo
+			. '/archive/' . $version . '.zip'
+		);
 	}
 }
 
-// On Activation. Start the Plugin class.
-$CP_release_link = new LatestGithubRelease;
-$CP_release_link->register();
+LatestGithubRelease::register();


### PR DESCRIPTION
This PR updates the plugin to use static functions (there is no need to create a new instance of the class) and to have code that is re-usable by other plugins.

The shortcode still works the same way, but since some function signatures changed, this should be a new major version (v2.0.0).

We're using this code to drive the new URLs like https://www.classicpress.net/latest.json and https://www.classicpress.net/latest.zip :

```php
$github_params = [ 'user' => 'ClassicPress', 'repo' => 'ClassicPress-release' ];

$release_data = LatestGithubRelease::get_release_data_cached( $github_params );
if ( is_wp_error( $release_data ) ) {
	return $release_data;
}

$zip_url = LatestGithubRelease::get_zip_url_for_release( $release_data );
if ( is_wp_error( $zip_url ) ) {
	return $zip_url;
}

if ( $request['format'] === 'zip' ) {
	wp_redirect( $zip_url );
	die();
}

$data = $github_params;
$data['version'] = $release_data['tag_name'];
$data['published_at'] = $release_data['published_at'];
$data['github_web_url'] = $release_data['html_url'];
$data['github_api_url'] = $release_data['url'];
$data['zip_url'] = $zip_url;

return $data;
```